### PR TITLE
feat(TxBuilder): add parse method

### DIFF
--- a/src/TxBuilder.ts
+++ b/src/TxBuilder.ts
@@ -1,6 +1,7 @@
+import { DEFAULT_OPTIONS } from "./constants";
+import { ErrorCode, ParsingError, TransactionParsingError, validateContractMethod } from "./errors";
 import { Address, BatchTransaction, Options } from "./types";
 import { addChecksum } from "./utils";
-import { DEFAULT_OPTIONS } from "./constants";
 
 export default class TxBuilder {
   static batch = (safe: Address, transactions: BatchTransaction[], options: Options = {}) =>
@@ -17,4 +18,40 @@ export default class TxBuilder {
       },
       transactions,
     });
+
+  static parse = (batch: string): BatchTransaction[] => {
+    const parsedBatch = JSON.parse(batch);
+    if (
+      Array.isArray(parsedBatch) ||
+      !parsedBatch.transactions ||
+      !Array.isArray(parsedBatch.transactions)
+    )
+      throw new ParsingError(ErrorCode.wrongFormat);
+
+    return (parsedBatch.transactions as any[]).map((tx: any, i) => {
+      if (typeof tx !== "object") throw new TransactionParsingError(i, ErrorCode.wrongTxFormat);
+      const { to, value, data, contractMethod, contractInputsValues } = tx;
+      if (typeof to !== "string")
+        throw new TransactionParsingError(i, ErrorCode.wrongTxFormat, "to");
+      if (typeof value !== "string")
+        throw new TransactionParsingError(i, ErrorCode.wrongTxFormat, "value");
+      if (data !== null && data !== undefined && typeof data !== "string")
+        throw new TransactionParsingError(i, ErrorCode.wrongTxFormat, "data");
+      if (
+        contractInputsValues !== undefined &&
+        (typeof contractInputsValues !== "object" ||
+          !Object.values(contractInputsValues).every((v) => typeof v === "string"))
+      )
+        throw new TransactionParsingError(i, ErrorCode.wrongTxFormat, "contractInputsValues");
+
+      const contractMethodError = new TransactionParsingError(
+        i,
+        ErrorCode.wrongTxFormat,
+        "contractMethod"
+      );
+
+      const validatedContractMethod = validateContractMethod(contractMethod, contractMethodError);
+      return { to, value, data, contractMethod: validatedContractMethod, contractInputsValues };
+    });
+  };
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,55 @@
+import { ContractInput } from "./types";
+
+export enum ErrorCode {
+  wrongFormat = "WRONG_FORMAT",
+  wrongTxFormat = "WRONG_TRANSACTION_FORMAT",
+}
+
+export class ParsingError extends Error {
+  constructor(public code: ErrorCode) {
+    super(`Cannot parse transactions.\nError code: ${code}`);
+    this.name = "TxBuilderParsingError";
+  }
+}
+
+export class TransactionParsingError extends ParsingError {
+  constructor(public index: number, code: ErrorCode, public parameter?: string) {
+    super(code);
+    this.message = `Cannot parse transaction at index ${index}.\nError code: ${code}`;
+    if (parameter) this.message += `\nParameter: ${parameter}`;
+  }
+}
+
+export const validateContractMethod = (contractMethod: any, error: TransactionParsingError) => {
+  if (contractMethod === undefined) return contractMethod;
+  if (typeof contractMethod !== "object") throw error;
+
+  const { inputs, name, payable } = contractMethod;
+
+  if (typeof payable !== "boolean") throw error;
+  if (typeof name !== "string") throw error;
+  if (!Array.isArray(inputs)) throw error;
+  if (!inputs.every((input) => validateContractInput(input, error))) throw error;
+  return { inputs, name, payable };
+};
+
+const validateContractInput = (
+  contractInput: any,
+  error: TransactionParsingError
+): ContractInput => {
+  if (typeof contractInput !== "object") throw error;
+  const { internalType, name, type, components } = contractInput;
+
+  if (typeof internalType !== "string") throw error;
+  if (typeof name !== "string") throw error;
+  if (typeof type !== "string") throw error;
+
+  if (components === undefined) return { internalType, name, type };
+  if (!Array.isArray(components)) throw error;
+  return {
+    internalType,
+    name,
+    type,
+    components: components.map((component) => validateContractInput(component, error)),
+  };
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,24 +7,36 @@ export enum ErrorCode {
 }
 
 export class ParsingError extends Error {
-  constructor(public code: ErrorCode) {
+  constructor(protected code: ErrorCode) {
     super(`Cannot parse transactions.\nError code: ${code}`);
     this.name = "TxBuilderParsingError";
+  }
+
+  get params() {
+    return { code: this.code };
   }
 }
 
 export class TransactionParsingError extends ParsingError {
-  constructor(public index: number, public parameter?: string) {
+  constructor(protected index: number, protected parameter?: string) {
     super(ErrorCode.wrongTxFormat);
     this.message = `Cannot parse transaction at index ${index}.`;
     if (parameter) this.message += `\nParameter: ${parameter}`;
   }
+
+  get params() {
+    return { code: this.code, index: this.index, parameter: this.parameter };
+  }
 }
 
 export class ChecksumParsingError extends ParsingError {
-  constructor(expected?: string, computed?: string) {
+  constructor(protected expected?: string, protected computed?: string) {
     super(ErrorCode.invalidChecksum);
     this.message = `Invalid checksum.\nExpected: ${expected}\nComputed: ${computed}`;
+  }
+
+  get params() {
+    return { code: this.code, expected: this.expected, computed: this.computed };
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@ import { ContractInput } from "./types";
 export enum ErrorCode {
   wrongFormat = "WRONG_FORMAT",
   wrongTxFormat = "WRONG_TRANSACTION_FORMAT",
+  invalidChecksum = "INVALID_CHECKSUM",
 }
 
 export class ParsingError extends Error {
@@ -13,10 +14,17 @@ export class ParsingError extends Error {
 }
 
 export class TransactionParsingError extends ParsingError {
-  constructor(public index: number, code: ErrorCode, public parameter?: string) {
-    super(code);
-    this.message = `Cannot parse transaction at index ${index}.\nError code: ${code}`;
+  constructor(public index: number, public parameter?: string) {
+    super(ErrorCode.wrongTxFormat);
+    this.message = `Cannot parse transaction at index ${index}.`;
     if (parameter) this.message += `\nParameter: ${parameter}`;
+  }
+}
+
+export class ChecksumParsingError extends ParsingError {
+  constructor(expected?: string, computed?: string) {
+    super(ErrorCode.invalidChecksum);
+    this.message = `Invalid checksum.\nExpected: ${expected}\nComputed: ${computed}`;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default as TxBuilder } from "./TxBuilder";
-export { ErrorCode, ParsingError, TransactionParsingError } from "./errors";
+export { ErrorCode, ParsingError, TransactionParsingError, ChecksumParsingError } from "./errors";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as TxBuilder } from "./TxBuilder";
+export { ErrorCode, ParsingError, TransactionParsingError } from "./errors";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,10 +24,12 @@ export const serializeJSONObject = (json: any): string => {
   return `${JSON.stringify(json, stringifyReplacer)}`;
 };
 
-const calculateChecksum = (batchFile: BatchFile): string | undefined => {
+export const calculateChecksum = (batchFile: BatchFile): string | undefined => {
+  const batchFileMeta = { ...batchFile.meta };
+  delete batchFileMeta.checksum;
   const serialized = serializeJSONObject({
     ...batchFile,
-    meta: { ...batchFile.meta, name: null },
+    meta: { ...batchFileMeta, name: null },
   });
   const sha = utils.solidityKeccak256(["string"], [serialized]);
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,8 +2,14 @@ import { constants } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 
 import { TxBuilder } from "../src";
-import { ErrorCode, ParsingError, TransactionParsingError } from "../src/errors";
+import {
+  ChecksumParsingError,
+  ErrorCode,
+  ParsingError,
+  TransactionParsingError,
+} from "../src/errors";
 import { BatchFile } from "../src/types";
+import { addChecksum } from "../src/utils";
 
 describe("@morpho-labs/gnosis-tx-builder", () => {
   let txBuilderJson: BatchFile;
@@ -65,137 +71,210 @@ describe("@morpho-labs/gnosis-tx-builder", () => {
   });
 
   describe("Should correctly parse a batch file", () => {
+    it("should return an error if the checksum is invalid", () => {
+      expect(() =>
+        TxBuilder.parse(
+          JSON.stringify({
+            ...txBuilderJson,
+            meta: { ...txBuilderJson.meta, checksum: "invalid checksum" },
+          })
+        )
+      ).toThrow(new ChecksumParsingError("invalid checksum", txBuilderJson.meta.checksum));
+    });
+
     it("should return an error if the batch file can't be parsed", () => {
+      // not an object
       expect(() => TxBuilder.parse(JSON.stringify(["not an object"]))).toThrow(
         new ParsingError(ErrorCode.wrongFormat)
       );
+
       expect(() =>
-        TxBuilder.parse(JSON.stringify({ name: "object without transactions" }))
+        //@ts-expect-error object without transactions
+        TxBuilder.parse(JSON.stringify(addChecksum({ ...txBuilderJson, transactions: undefined })))
       ).toThrow(new ParsingError(ErrorCode.wrongFormat));
-      expect(() => TxBuilder.parse(JSON.stringify({ transactions: "not an array" }))).toThrow(
-        new ParsingError(ErrorCode.wrongFormat)
-      );
+
+      expect(() =>
+        TxBuilder.parse(
+          //@ts-expect-error transactions not an array
+          JSON.stringify(addChecksum({ ...txBuilderJson, transactions: "not an array" }))
+        )
+      ).toThrow(new ParsingError(ErrorCode.wrongFormat));
     });
     it("should return an error if a transaction doesn't have the correct type", () => {
-      expect(() => TxBuilder.parse(JSON.stringify({ transactions: ["not an object"] }))).toThrow(
-        new TransactionParsingError(0, ErrorCode.wrongTxFormat)
-      );
-      expect(() =>
-        TxBuilder.parse(JSON.stringify({ transactions: [{ ...transactions[0], to: 123 }] }))
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "to"));
-      expect(() =>
-        TxBuilder.parse(JSON.stringify({ transactions: [{ ...transactions[0], value: 123 }] }))
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "value"));
-      expect(() =>
-        TxBuilder.parse(JSON.stringify({ transactions: [{ ...transactions[0], data: 123 }] }))
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "data"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [{ ...transactions[0], contractInputsValues: "not an object" }],
-          })
+          //@ts-expect-error wrong transaction type
+          JSON.stringify(addChecksum({ ...txBuilderJson, transactions: ["not an object"] }))
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractInputsValues"));
+      ).toThrow(new TransactionParsingError(0));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              { ...transactions[0], contractInputsValues: { string: "", notAString: 0 } },
-            ],
-          })
+          JSON.stringify(
+            //@ts-expect-error wrong transaction type for property "to"
+            addChecksum({ ...txBuilderJson, transactions: [{ ...transactions[0], to: 123 }] })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractInputsValues"));
+      ).toThrow(new TransactionParsingError(0, "to"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [{ ...transactions[0], contractMethod: "not an object" }],
-          })
+          JSON.stringify(
+            //@ts-expect-error wrong transaction type for property "value"
+            addChecksum({ ...txBuilderJson, transactions: [{ ...transactions[0], value: 123 }] })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "value"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              { ...transactions[0], contractMethod: { inputs: [], name: 0, payable: true } },
-            ],
-          })
+          JSON.stringify(
+            //@ts-expect-error wrong transaction type for property "data"
+            addChecksum({ ...txBuilderJson, transactions: [{ ...transactions[0], data: 123 }] })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "data"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              {
-                ...transactions[0],
-                contractMethod: { inputs: [], name: "string", payable: "not a boolean" },
-              },
-            ],
-          })
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              //@ts-expect-error wrong transaction type for property "contractInputsValues"
+              transactions: [{ ...transactions[0], contractInputsValues: "not an object" }],
+            })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "contractInputsValues"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              {
-                ...transactions[0],
-                contractMethod: { inputs: ["not an object"], name: "string", payable: true },
-              },
-            ],
-          })
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                //@ts-expect-error wrong transaction type for property "contractInputsValues"
+                { ...transactions[0], contractInputsValues: { string: "", notAString: 0 } },
+              ],
+            })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "contractInputsValues"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              {
-                ...transactions[0],
-                contractMethod: {
-                  inputs: [{ name: 0, type: "", components: [], internalType: "" }],
-                  name: "string",
-                  payable: true,
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              //@ts-expect-error wrong transaction type for property "contractMethod"
+              transactions: [{ ...transactions[0], contractMethod: "not an object" }],
+            })
+          )
+        )
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
+      expect(() =>
+        TxBuilder.parse(
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                //@ts-expect-error wrong transaction type for property "contractMethod.name"
+                { ...transactions[0], contractMethod: { inputs: [], name: 0, payable: true } },
+              ],
+            })
+          )
+        )
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
+      expect(() =>
+        TxBuilder.parse(
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                {
+                  ...transactions[0],
+                  //@ts-expect-error wrong transaction type for property "contractMethod.payable"
+                  contractMethod: { inputs: [], name: "string", payable: "not a boolean" },
                 },
-              },
-            ],
-          })
+              ],
+            })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              {
-                ...transactions[0],
-                contractMethod: {
-                  inputs: [{ name: "", type: 0, components: [], internalType: "" }],
-                  name: "string",
-                  payable: true,
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                {
+                  ...transactions[0],
+                  //@ts-expect-error wrong transaction type for property "contractMethod.inputs"
+                  contractMethod: { inputs: ["not an object"], name: "string", payable: true },
                 },
-              },
-            ],
-          })
+              ],
+            })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
       expect(() =>
         TxBuilder.parse(
-          JSON.stringify({
-            transactions: [
-              {
-                ...transactions[0],
-                contractMethod: {
-                  inputs: [{ name: "", type: "", components: [], internalType: 0 }],
-                  name: "string",
-                  payable: true,
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                {
+                  ...transactions[0],
+                  contractMethod: {
+                    //@ts-expect-error wrong transaction type for property "contractMethod.inputs[0].name"
+                    inputs: [{ name: 0, type: "", components: [], internalType: "" }],
+                    name: "string",
+                    payable: true,
+                  },
                 },
-              },
-            ],
-          })
+              ],
+            })
+          )
         )
-      ).toThrow(new TransactionParsingError(0, ErrorCode.wrongTxFormat, "contractMethod"));
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
+      expect(() =>
+        TxBuilder.parse(
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                {
+                  ...transactions[0],
+                  contractMethod: {
+                    //@ts-expect-error wrong transaction type for property "contractMethod.inputs[0].type"
+                    inputs: [{ name: "", type: 0, components: [], internalType: "" }],
+                    name: "string",
+                    payable: true,
+                  },
+                },
+              ],
+            })
+          )
+        )
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
+      expect(() =>
+        TxBuilder.parse(
+          JSON.stringify(
+            addChecksum({
+              ...txBuilderJson,
+              transactions: [
+                {
+                  ...transactions[0],
+                  contractMethod: {
+                    //@ts-expect-error wrong transaction type for property "contractMethod.inputs[0].internalType"
+                    inputs: [{ name: "", type: "", components: [], internalType: 0 }],
+                    name: "string",
+                    payable: true,
+                  },
+                },
+              ],
+            })
+          )
+        )
+      ).toThrow(new TransactionParsingError(0, "contractMethod"));
     });
     it("should parse correcly several transactions", () => {
-      const batchFileMock = {
+      const batchFileMock = addChecksum({
+        ...txBuilderJson,
         transactions: [
           {
             to: "0x0001",
@@ -224,7 +303,7 @@ describe("@morpho-labs/gnosis-tx-builder", () => {
             },
           },
         ],
-      };
+      });
 
       expect(() => TxBuilder.parse(JSON.stringify(batchFileMock))).not.toThrow();
       expect(TxBuilder.parse(JSON.stringify(batchFileMock))).toEqual(batchFileMock.transactions);


### PR DESCRIPTION

### Description of change
Added a `parseTransactions` method that takes a JSON as an input and returns parsed transactions (or throws an error if the format is not the right one).

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
